### PR TITLE
Update ofxOculusDK2.cpp

### DIFF
--- a/src/ofxOculusDK2.cpp
+++ b/src/ofxOculusDK2.cpp
@@ -471,7 +471,7 @@ void ofxOculusDK2::fullscreenOnRift() {
     int numDisplays= displayCount;
     
     // If two displays present, use the 2nd one. If one, use the first.
-    int whichDisplay = hmd->DisplayId;
+    int whichDisplay = numDisplays > 1 ? 1 : 0;
     
     int displayHeight= CGDisplayPixelsHigh ( displays[whichDisplay] );
     int displayWidth= CGDisplayPixelsWide ( displays[whichDisplay] );


### PR DESCRIPTION
I was trying ofxOculusDK2 on with oF 0.9 RC2 (on OS X 10.10.5 with Xcode 7.1), and found the `hmd->DisplayId` field is not valid (therefore accessing `displays[whichDisplay]` on the next line crashes).  It looks like their `DisplayId` field may have been scheduled for deletion.

I simply implemented what your comment suggests (take 2nd one if there are multiple displays, otherwise use the first).  This works with Oculus runtime 0.5.0.1 and Oculus on the second display.

(or is it just me, and the code as-is works for other people on Mac?)