### PR TITLE
Fix crash with bad monitor id; add method to get full Oculus pose

### DIFF
--- a/src/ofxOculusDK2.h
+++ b/src/ofxOculusDK2.h
@@ -108,6 +108,7 @@ class ofxOculusDK2
 	ofQuaternion getOrientationQuat();
 	ofMatrix4x4 getOrientationMat();
     ofVec3f getTranslation();
+    ofMatrix4x4 getFullHeadPose();
 	
 	//default 1 has more constrained mouse movement,
 	//while turning it up increases the reach of the mouse


### PR DESCRIPTION
We now figure out the Oculus monitor id in a more reliable way.  Previously, it was sometimes crashing in `fullscreenOnRift()` because `hmd->DisplayId` was uninitialized.

I also implemented the missing `getTranslation()` method (was declared in the header but not implemented), and added a new `getFullHeadPose()` method, that returns the full pose of the Oculus camera (including its parent ofCamera).

This is a better fix than my earlier pull request, which I will retract.
